### PR TITLE
fix: FIx error due to unclosed hr tags

### DIFF
--- a/docs/guides/credits.md
+++ b/docs/guides/credits.md
@@ -27,6 +27,6 @@ description: The people behind Aurora.
 - [Gareth Widlansky](https://github.com/gerblesh)
 - [Ryan Brue](https://github.com/ryanabx)
 
-<hr>
+---
 
 View the full list of [Aurora contributors](https://github.com/ublue-os/aurora/graphs/contributors).

--- a/docs/guides/quadlet.md
+++ b/docs/guides/quadlet.md
@@ -167,6 +167,6 @@ https://podman.io/
 - https://docs.podman.io/en/stable/markdown/podman-systemd.unit.5.html
 - https://www.redhat.com/en/blog/quadlet-podman
 
-<hr>
+---
 
 Original documentation borrowed from [Bazzite documentation](https://docs.bazzite.gg/Installing_and_Managing_Software/Quadlet/) by [@asen23](https://github.com/asen23)

--- a/docs/guides/system-requirements.md
+++ b/docs/guides/system-requirements.md
@@ -8,7 +8,7 @@ Using Aurora on your computer does not require any special sauce, but there are 
 - A recent dual-core or higher multicore processor with at least 2 GHz
 - 4 GB of RAM
 - An SSD with at least 30GB of free space to have space for now and future updates
-<hr/>
+---
 > Why an SSD for the install?
 
 An HDD will work too but updates and other I/O heavy operations you might do when computing will suffer greatly and will drastically decrease your experience working with Aurora or any other OS in general.


### PR DESCRIPTION
Fix errors from the unclosed `<hr>` tags. 

I opted to just use markdown syntax and adjusted the one correctly closed usage of `<hr/>` to be consistent.

#31 