### PR TITLE
Fix links, typos, and errors

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-     
+
       - name: Prettify code
         uses: creyD/prettier_action@v4.3
-        with: 
+        with:
           prettier_options: --write **/*.{ts,js,md}
           github_token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aurora Docs
 
-These docs are pretty sparse on purpose as Aurora's intended to be invisible. Ideally the docs should be able to be consumed in one sitting.
+These docs are pretty sparse on purpose as Aurora is intended to be invisible. Ideally, the docs should be able to be consumed in one sitting.
 
 ## Guidelines
 

--- a/docs/guides/basic-usage.md
+++ b/docs/guides/basic-usage.md
@@ -23,7 +23,7 @@ Manage installed Flatpaks by downgrading, backing up user data, and adding addit
 
 ### Pre-Installed Aurora Packages
 
-Unfortunately, due to a limitation with OCI images, there are too many downsides to recommend uninstalling the pre-installed packages that ship with Aurora without [forking the project](https://github.com/ublue-os/bluefin/fork), building your own based on our [template](https://github.com/ublue-os/image-template), or using the unaffiliated [Blue-Build](https://blue-build.org/learn/universal-blue/) project.
+Unfortunately, due to a limitation with OCI images, there are too many downsides to recommend uninstalling the pre-installed packages that ship with Aurora without [forking the project](https://github.com/ublue-os/aurora/fork), building your own based on our [template](https://github.com/ublue-os/image-template), or using the unaffiliated [Blue-Build](https://blue-build.org/learn/universal-blue/) project.
 
 These downsides include:
 

--- a/docs/guides/intro.md
+++ b/docs/guides/intro.md
@@ -22,7 +22,7 @@ System updates are image-based and automatic. Applications are logically separat
 
 ## For Users
 
-- [Ptyxis terminal](https://universal-blue.discourse.group/docs?topic=300) for container-focused workflows
+- [Ptyxis terminal](https://devsuite.app/ptyxis/) for container-focused workflows
   - [Boxbuddy](https://flathub.org/apps/io.github.dvlv.boxbuddyrs) for container management
 - [Tailscale](https://tailscale.com) - included for VPN along with `wireguard-tools`
 - KDE Discover with [Flathub](https://flathub.org):

--- a/docs/guides/quadlet.md
+++ b/docs/guides/quadlet.md
@@ -90,7 +90,7 @@ By default quadlet require full repository name. Most image are in docker hub so
 
 ### Running Rootful Container as Quadlet
 
-While ideally you would run all container using rootless podman, sadly not all container will work with it. If you noticed in the beginning, this guide used nginx-unprivileged rather than the normal nginx, this because it need root to function. To use rootful podman, you will need to use different quadlet path and run using root systemctl (without `--user`).
+While ideally you would run all container using rootless podman, sadly not all container will work with it. If you noticed in the beginning, this guide used nginx-unprivileged rather than the normal nginx, this because it needs root to function. To use rootful podman, you will need to use a different quadlet path and run using root systemctl (without `--user`).
 
 Rootful Quadlet Path
 

--- a/docs/guides/software.md
+++ b/docs/guides/software.md
@@ -5,7 +5,7 @@ description: How to install software on Aurora
 
 ## Flatpak
 
-[Flatpak](https://www.flatpak.org/) is the primary package method for graphical applications. By default, the [Flathub](https://www.flathub.org) remote is used which contains several popular applications to install from. Install Flatpaks with the **Discover** application.
+[Flatpak](https://flatpak.org) is the primary package method for graphical applications. By default, the [Flathub](https://www.flathub.org) remote is used which contains several popular applications to install from. Install Flatpaks with the **Discover** application.
 
 ## Homebrew
 
@@ -29,4 +29,4 @@ Layer RPM packages to the host like a traditional Linux operating system which c
 - High potential for broken upgrades due to dependency issues.
 - Slower updates due to adding an extra layer to the deployment.
 
-Read more about layering packages to the host [here](https://docs.getaurora.dev/guides/layerapp/).
+Read more about layering packages to the host [here](/guides/layerapp).

--- a/docs/guides/start-icon.md
+++ b/docs/guides/start-icon.md
@@ -3,7 +3,7 @@ title: How to change your start icon
 description: How to change your start icon
 ---
 
-Updating your start icon in Aurora is a straight-forward process. You'll have access to both a sleek white version and a vibrant, colorful option to customize your experience. By default, the colorful version is selected.
+Updating your start icon in Aurora is a straight-forward process. You'll have access to both a sleek white version and a vibrant, colorful option to customize your experience. By default, the white version is selected.
 
 1. Firstly, open the settings for the application launcher. This can be done by right clicking the application launcher icon on your taskbar. It will show a menu, select "Configure Application Launcher".
 


### PR DESCRIPTION
This pull request includes a handful of  documentation updates to improve clarity, correct references, and fix minor errors across multiple files. The most important changes are summarized below:

Corrections and improvements to documentation:

* [`docs/guides/basic-usage.md`](diffhunk://#diff-dd2188f9a1a854f8939d1d6935972f68bd6812282cb4fdce2bf940adb724eec8L26-R26): Updated the project fork link to point to the correct repository.
* [`docs/guides/intro.md`](diffhunk://#diff-63d22431ac26359ba1bc8a0c544d73bb93488686b3f87416bdaede39dcef6693L25-R25): Fixed the link to the Ptyxis terminal to point to the correct URL because the prior URL was broken.
* [`docs/guides/software.md`](diffhunk://#diff-a2f7cce58a1ba6cc11b870fb7a6750854b3431bb2b0ce6271ddb2e5958817322L8-R8): 
  * Updated Flatpak's URL because the prior URL was not working due to: https://github.com/flatpak/flatpak.github.io/issues/697 [[1]](diffhunk://#diff-a2f7cce58a1ba6cc11b870fb7a6750854b3431bb2b0ce6271ddb2e5958817322L8-R8) 
  * Swapped an absolute URL to relative URL.. [[2]](diffhunk://#diff-a2f7cce58a1ba6cc11b870fb7a6750854b3431bb2b0ce6271ddb2e5958817322L32-R32)
* Fixed a handful of grammatical errors.
* Updated default icon documentation from colorful to white. It appears that the white start icon is enabled by default in Aurora as of earlier this week.