### PR TITLE
fix: GitHub Action to scan correct folders for typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Check for typos
         uses: crate-ci/typos@592b36d23c62cb378f6097a292bc902ee73f93ef # version 1.0.4
         with:
-          files: ./README.md ./docs ./pages
+          files: ./README.md ./docs


### PR DESCRIPTION
I noticed in #33 that the `check-spelling` action was failing due to attempting to scan a folder that doesn't exist.
![image](https://github.com/user-attachments/assets/6695d91c-b8a9-49ae-bade-f9929c1931dc)

The pages folder doesn't exist and causes the `typos` command to fail, so I just removed it.

I validated locally, but saw a slightly different error message. It's possible there is another issue as well, but this should at least fix _something_.
![image](https://github.com/user-attachments/assets/eb9fea69-1633-49c4-9256-7fffff8af4be)
 
